### PR TITLE
fixes to-stateless converting when not supposed to

### DIFF
--- a/debug/debug-to-stateless.js
+++ b/debug/debug-to-stateless.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 const statelessTransform = require('../source/transforms/to-stateless');
+const ensureCanConvert = require('../source/utils/ensure-can-convert-to-stateless');
+const eslintrc = require('../.eslintrc.json');
 
 const statefulComponentSource = fs.readFileSync(
   path.join(
@@ -10,5 +12,7 @@ const statefulComponentSource = fs.readFileSync(
   ),
   'utf-8'
 );
+
+ensureCanConvert(statefulComponentSource, eslintrc);
 
 statelessTransform(statefulComponentSource, 'component-stateful');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/react-scripts",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Utility scripts for React projects",
   "author": "Asbjørn Hegdahl <asbjorn.hegdahl@creuna.no>",
   "contributors": [
@@ -24,6 +24,7 @@
     "@creuna/prompt": "^1.0.0",
     "@creuna/utils": "^0.3.4",
     "ava": "^0.25.0",
+    "babel-eslint": "^8.2.3",
     "babel-types": "^6.26.0",
     "chalk": "^2.4.1",
     "eslint": "^4.19.1",
@@ -33,7 +34,6 @@
     "prettier": "^1.13.4"
   },
   "devDependencies": {
-    "babel-eslint": "^8.2.3",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0"
   }

--- a/source/utils/ensure-can-convert-to-stateless.js
+++ b/source/utils/ensure-can-convert-to-stateless.js
@@ -22,15 +22,23 @@ module.exports = function(
   showLogError = true,
   exitOnFail = true
 ) {
-  if (
-    !linter.verify(sourceCode, {
-      parser: eslintrc.parser,
-      parserOptions: eslintrc.parserOptions,
-      rules: {
-        'react/prefer-stateless-function': 1
-      }
-    }).length
-  ) {
+  const errors = linter.verify(sourceCode, {
+    parser: 'babel-eslint',
+    parserOptions: eslintrc.parserOptions,
+    rules: {
+      'react/prefer-stateless-function': 1
+    }
+  });
+  const fatalError = errors.find(error => error.fatal);
+
+  if (fatalError) {
+    console.log(chalk.redBright(fatalError.message));
+    console.log(chalk.redBright('Aborting.'));
+    process.exit(0);
+  }
+
+  // If the component can be converted, eslint will return a warning that the component should be converted. If there are no errors, the component can't be converted.
+  if (!errors.length) {
     if (showLogError) {
       console.log(
         `😭  ${chalk.redBright(`Component can't be converted. Make sure that there is no:

--- a/source/utils/ensure-can-convert-to-stateless.js
+++ b/source/utils/ensure-can-convert-to-stateless.js
@@ -37,7 +37,7 @@ module.exports = function(
     process.exit(0);
   }
 
-  // If the component can be converted, eslint will return a warning that the component should be converted. If there are no errors, the component can't be converted.
+  // If the component can be converted, eslint will return a warning that the component should be converted. If there are no warnings, the component can't be converted.
   if (!errors.length) {
     if (showLogError) {
       console.log(


### PR DESCRIPTION
Fixes #6 

Added 'babel-eslint' to dependencies and added some safety to ensure-can-convert-to-stateless