### PR TITLE
made git-configs() override all falsy parameters instead of only unde…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [https://github.com/Creuna-Oslo/react-scripts/pull/24]()
 
-- Fixed issue that made `get-configs` crash when user was missing eslint.config file.
+- Fixes issue that made `get-configs` unable to handle null argument.
 
 # 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.0.1
+
+[https://github.com/Creuna-Oslo/react-scripts/pull/24]()
+
+- Fixed issue that made `get-configs` crash when user was missing eslint.config file.
+
 # 4.0.0
 
 [https://github.com/Creuna-Oslo/react-scripts/pull/23]()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/react-scripts",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Utility scripts for React projects",
   "author": "Asbjørn Hegdahl <asbjorn.hegdahl@creuna.no>",
   "contributors": [

--- a/source/utils/get-configs.js
+++ b/source/utils/get-configs.js
@@ -20,7 +20,8 @@ const getPrettierConfig = eslintConfig => {
 };
 
 // Get configs or fallbacks based on provided eslint config
-module.exports = function(eslintConfig = {}) {
+module.exports = function(eslintConfig) {
+  eslintConfig = eslintConfig || {};
   return {
     eslintConfig: Object.assign(eslintConfigDefault, eslintConfig),
     prettierConfig: Object.assign(

--- a/source/utils/get-configs.js
+++ b/source/utils/get-configs.js
@@ -20,13 +20,12 @@ const getPrettierConfig = eslintConfig => {
 };
 
 // Get configs or fallbacks based on provided eslint config
-module.exports = function(eslintConfig) {
-  eslintConfig = eslintConfig || {};
+module.exports = function(eslintConfig = {}) {
   return {
     eslintConfig: Object.assign(eslintConfigDefault, eslintConfig),
     prettierConfig: Object.assign(
       { parser: 'babylon' },
-      getPrettierConfig(eslintConfig)
+      getPrettierConfig(eslintConfig || {})
     )
   };
 };

--- a/source/utils/get-configs.js
+++ b/source/utils/get-configs.js
@@ -20,7 +20,7 @@ const getPrettierConfig = eslintConfig => {
 };
 
 // Get configs or fallbacks based on provided eslint config
-module.exports = function(eslintConfig = {}) {
+module.exports = function(eslintConfig) {
   return {
     eslintConfig: Object.assign(eslintConfigDefault, eslintConfig),
     prettierConfig: Object.assign(


### PR DESCRIPTION
Found a bug when renaming component without .eslintrc.json
"Cannot read property 'rules' of null"

eslintConfig becomes null when there is no .eslintrc.json and 
get-configs() only overrides undefined values
